### PR TITLE
Bug fix in parse.repo() for repo with sub-directory

### DIFF
--- a/R/parse.repo.R
+++ b/R/parse.repo.R
@@ -12,9 +12,9 @@ parse.repo <- function(repo)
 
   username <- head(x, 1)
   repo.ref <- tail(x, 1)
-  subdir <- if(length(x) == 2) "" else x[2]
+  subdir <- if(length(x) == 2) "" else unlist(strsplit(x[3], "@"))[1]
 
-  repo <- unlist(strsplit(repo.ref, "@"))[1]
+  repo <- if(length(x) == 2) unlist(strsplit(repo.ref, "@"))[1] else x[2]
   ref <- if(grepl("@", repo.ref)) unlist(strsplit(repo.ref, "@"))[2] else ""
 
   list(username=username, repo=repo, subdir=subdir, ref=ref)


### PR DESCRIPTION
Github repository source with a sub-directory (e.g., `fishfollower/SAM/stockassessment@a295ef2f11`) in `SOFTWARE.bib` was incorrectly parsed. This patch hopefully fixes it.