### PR TITLE
Allow multiple bib$source entries

### DIFF
--- a/R/process.entry.R
+++ b/R/process.entry.R
@@ -16,6 +16,7 @@ process.entry <- function(bib, quiet = FALSE, force = FALSE, clean = FALSE) {
   }
 
   ## If source contains multiple files then split into vector
+  bib$source <- gsub(" +", "\n", bib$source) # treat space in source as newline
   bib$source <- trimws(unlist(strsplit(bib$source, "\\n")))
   bib$source <- sub(",$", "", bib$source) # remove trailing comma
   bib$source <- bib$source[bib$source != ""] # remove empty strings


### PR DESCRIPTION
icesTAF versions 3.0 to 3.5 allowed users to specify multiple `source` entries that share a `prefix`:

```
@Misc{pictures,
  originator = {TAF},
  year       = {2021},
  title      = {Two pictures},
  access     = {Public},
  prefix     = {https://www.ices.dk/SiteCollectionImages/TAF/},
  source     = {TAfbanner.png,
                TAF_info_gfx.png},
}
```
Version 3.6.0 dropped this support, but with this pull request we can bring it back.